### PR TITLE
Update version 0.0.8 -> 0.0.9

### DIFF
--- a/dwavebinarycsp/package_info.py
+++ b/dwavebinarycsp/package_info.py
@@ -14,7 +14,7 @@
 #
 # ================================================================================================
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Solves constraints satisfaction problems with binary quadratic model samplers'


### PR DESCRIPTION
Back to wheels. Avoid penalty model factory availability check during
install; rather, on it on import and first use.