### PR TITLE
Feature/75 dwavebinarycsp ignoring min classical gap

### DIFF
--- a/dwavebinarycsp/compilers/stitcher.py
+++ b/dwavebinarycsp/compilers/stitcher.py
@@ -186,7 +186,7 @@ def stitch(csp, min_classical_gap=2.0, max_graph_size=8):
         # developer note: we could cache them and relabel, for now though let's do the simple thing
         # penalty_models[configurations] = pmodel
 
-        if pmodel is None:
+        else:
             msg = ("No penalty model can be build for constraint {}".format(const))
             raise ImpossibleBQM(msg)
 

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -239,6 +239,31 @@ class TestStitch(unittest.TestCase):
         with self.assertRaises(dwavebinarycsp.exceptions.ImpossibleBQM):
             dwavebinarycsp.stitch(csp, min_classical_gap=4, max_graph_size=2)
 
+    def test_returned_gap_with_aux(self):
+        """Verify that stitch is only allowing gaps that satisfy min_classical_gap to be returned.
+        In this case, by allowing an auxiliary variable, the min_classical_gap should be achieved
+        and stitch should allow a bqm to be returned.
+        """
+        csp = dwavebinarycsp.ConstraintSatisfactionProblem("SPIN")
+        csp.add_constraint(operator.eq, ['a', 'b'])
+        min_classical_gap = 3
+
+        # No aux case: max_graph_size=2
+        # Note: Should not be possible to satisfy min_classical_gap
+        with self.assertRaises(dwavebinarycsp.exceptions.ImpossibleBQM):
+            dwavebinarycsp.stitch(csp, min_classical_gap=min_classical_gap, max_graph_size=2)
+
+        # One aux case: max_graph_size=3
+        # Note: min_classical_gap should be satisfied when we have three nodes
+        bqm = dwavebinarycsp.stitch(csp, min_classical_gap=min_classical_gap, max_graph_size=3)
+
+        # Verify one aux case
+        sampleset = dimod.ExactSolver().sample(bqm)
+        energy_array = sampleset.record['energy']
+        gap = max(energy_array) - min(energy_array)
+        self.assertGreaterEqual(gap, min_classical_gap)
+
+
 def powerset(iterable):
     "powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)"
     s = list(iterable)


### PR DESCRIPTION
* The issue was that the for-loop would complete with a penalty model that does not satisfy the gap. 
* Made fix: if gap-check-break does not occur, raise impossible bqm.
* Add unit tests for aux and no aux cases.
