### PR TITLE
dwavebinarycsp.stitch(..) now uses the updated Specification object f…

### DIFF
--- a/dwavebinarycsp/package_info.py
+++ b/dwavebinarycsp/package_info.py
@@ -14,7 +14,7 @@
 #
 # ================================================================================================
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 __author__ = 'D-Wave Systems Inc.'
 __authoremail__ = 'acondello@dwavesys.com'
 __description__ = 'Solves constraints satisfaction problems with binary quadratic model samplers'


### PR DESCRIPTION
…rom the updated penaltymodel-core. This means that this version of dwavebinarycsp is not compatible with older penaltymodels