### PR TITLE
Fix cache version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ penaltymodel==0.16.2
 penaltymodel-mip==0.2.0; (platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64") and python_version != "3.4"
 penaltymodel-maxgap==0.5.0; platform_machine != "x86_64" and platform_machine != "amd64" and platform_machine != "AMD64" or python_version == "3.4"
 penaltymodel-lp==0.1.0
-penaltymodel-cache==0.3.4
+penaltymodel-cache==0.4.0
 networkx==2.0
 dimod==0.7.2
 six==1.11.0


### PR DESCRIPTION
Penaltymodel-cache 0.3.4 does not exist in PyPi. Replace it with version 0.4.0