### PR TITLE
Feature/update xcode in circleci yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,11 @@ jobs:
       PYTHON: 3.8.0
       HOMEBREW_NO_AUTO_UPDATE: 1
 
+      # Force (lie about) macOS 10.9 binary compatibility.
+      # Needed for properly versioned wheels.
+      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+
     working_directory: ~/repo
 
     steps: 
@@ -89,7 +94,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1-macos-10.9
 
       - run:
           name: install python
@@ -99,7 +104,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1-macos-10.9
 
       - run:
           name: create virtualenv
@@ -127,24 +132,28 @@ jobs:
     environment:
       PYTHON: 3.7.4
       HOMEBREW_NO_AUTO_UPDATE: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-3.6:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.6.5
       HOMEBREW_NO_AUTO_UPDATE: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-3.5:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.5.5
       HOMEBREW_NO_AUTO_UPDATE: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-2.7:
     <<: *osx-tests-template
     environment:
       PYTHON: 2.7.15
       HOMEBREW_NO_AUTO_UPDATE: 1
+      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
-  test-3.7: &full-test-template
+  test-3.8: &full-test-template
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.8
 
     working_directory: ~/repo
 
@@ -50,26 +50,31 @@ jobs:
             . env/bin/activate
             make -C docs/ doctest
 
+  test-3.7:
+    <<: *full-test-template
+    docker:
+      - image: circleci/python:3.7
+
   test-3.6:
     <<: *full-test-template
     docker:
-      - image: circleci/python:3.6-jessie
+      - image: circleci/python:3.6
 
   test-3.5:
     <<: *full-test-template
     docker:
-      - image: circleci/python:3.5-jessie
+      - image: circleci/python:3.5
 
   test-2.7:
     <<: *full-test-template
     docker:
-      - image: circleci/python:2.7-jessie
+      - image: circleci/python:2.7
 
-  test-osx-3.7: &osx-tests-template
+  test-osx-3.8: &osx-tests-template
     macos:
       xcode: "11.2.1"
     environment:
-      PYTHON: 3.7.0
+      PYTHON: 3.8.0
       HOMEBREW_NO_AUTO_UPDATE: 1
 
     working_directory: ~/repo
@@ -117,6 +122,12 @@ jobs:
         
       - run: *run-tests-template
 
+  test-osx-3.7:
+    <<: *osx-tests-template
+    environment:
+      PYTHON: 3.7.4
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
   test-osx-3.6:
     <<: *osx-tests-template
     environment:
@@ -137,7 +148,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6-jessie
+      - image: circleci/python:3.6
 
     working_directory: ~/repo
 
@@ -189,10 +200,12 @@ workflows:
   version: 2
   test:
     jobs:
+      - test-3.8
       - test-3.7
       - test-3.6
       - test-3.5
       - test-2.7
+      - test-osx-3.8
       - test-osx-3.7
       - test-osx-3.6
       - test-osx-3.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test-3.8: &full-test-template
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.8-buster
 
     working_directory: ~/repo
 
@@ -53,22 +53,22 @@ jobs:
   test-3.7:
     <<: *full-test-template
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.7-stretch
 
   test-3.6:
     <<: *full-test-template
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-jessie
 
   test-3.5:
     <<: *full-test-template
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.5-jessie
 
   test-2.7:
     <<: *full-test-template
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:2.7-jessie
 
   test-osx-3.8: &osx-tests-template
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
 
   test-osx-3.7: &osx-tests-template
     macos:
-      xcode: "10.1.0"
+      xcode: "11.2.1"
     environment:
       PYTHON: 3.7.0
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -84,7 +84,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
 
       - run:
           name: install python
@@ -94,7 +94,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
 
       - run:
           name: create virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,14 +189,14 @@ workflows:
   version: 2
   test:
     jobs:
-     #  - test-3.7
-     #  - test-3.6
-     #  - test-3.5
-     #  - test-2.7
+      - test-3.7
+      - test-3.6
+      - test-3.5
+      - test-2.7
       - test-osx-3.7
-     #  - test-osx-3.6
-     #  - test-osx-3.5
-     #  - test-osx-2.7
+      - test-osx-3.6
+      - test-osx-3.5
+      - test-osx-2.7
       - deploy:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,6 @@ jobs:
       PYTHON: 3.8.0
       HOMEBREW_NO_AUTO_UPDATE: 1
 
-      # Force (lie about) macOS 10.9 binary compatibility.
-      # Needed for properly versioned wheels.
-      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
     working_directory: ~/repo
 
     steps: 
@@ -94,7 +89,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1-macos-10.9
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
 
       - run:
           name: install python
@@ -104,7 +99,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1-macos-10.9
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
 
       - run:
           name: create virtualenv
@@ -132,28 +127,24 @@ jobs:
     environment:
       PYTHON: 3.7.4
       HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-3.6:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.6.5
       HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-3.5:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.5.5
       HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   test-osx-2.7:
     <<: *osx-tests-template
     environment:
       PYTHON: 2.7.15
       HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,10 @@ jobs:
 
   test-osx-3.7: &osx-tests-template
     macos:
-      xcode: "9.4.1"
+      xcode: "10.1.0"
     environment:
       PYTHON: 3.7.0
-      # HOMEBREW_NO_AUTO_UPDATE: 1  # for 3.7 we need to update homebrew
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
     working_directory: ~/repo
 
@@ -189,14 +189,14 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-3.7
-      - test-3.6
-      - test-3.5
-      - test-2.7
+     #  - test-3.7
+     #  - test-3.6
+     #  - test-3.5
+     #  - test-2.7
       - test-osx-3.7
-      - test-osx-3.6
-      - test-osx-3.5
-      - test-osx-2.7
+     #  - test-osx-3.6
+     #  - test-osx-3.5
+     #  - test-osx-2.7
       - deploy:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,12 +200,12 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-3.8
+      # - test-3.8
       - test-3.7
       - test-3.6
       - test-3.5
       - test-2.7
-      - test-osx-3.8
+      # - test-osx-3.8
       - test-osx-3.7
       - test-osx-3.6
       - test-osx-3.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.6-jessie
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run:
           name: create virtualenv
@@ -29,7 +29,7 @@ jobs:
       - save_cache:
           paths:
             - ./env
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
         
       - run: &run-tests-template
           name: run unittests
@@ -116,14 +116,14 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          - v2-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run: *install-dependencies-template
 
       - save_cache:
           paths:
             - ./env
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
         
       - run: *run-tests-template
 


### PR DESCRIPTION
- I don't think we need to auto-update homebrew for osx py3.7. Previously, the tests would break at the `pyenv` install, but with the new xcode and explicitly calling out `HOMEBREW_NO_UPDATE`, things seem okay now.
- If you want to know the things I tried, please read my squashed commit, f81c243
