### PR TITLE
Fix doctest fails

### DIFF
--- a/dwavebinarycsp/compilers/stitcher.py
+++ b/dwavebinarycsp/compilers/stitcher.py
@@ -110,7 +110,6 @@ def stitch(csp, min_classical_gap=2.0, max_graph_size=8):
 
         This example finds for the previous example the minimum graph size.
 
-        >>> import dwavebinarycsp
         >>> import operator
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(operator.eq, ['a', 'b'])  # a == b

--- a/dwavebinarycsp/compilers/stitcher.py
+++ b/dwavebinarycsp/compilers/stitcher.py
@@ -61,20 +61,23 @@ def stitch(csp, min_classical_gap=2.0, max_graph_size=8):
     Examples:
         This example creates a binary-valued constraint satisfaction problem
         with two constraints, :math:`a = b` and :math:`b \\ne c`, and builds
-        a binary quadratic model with a minimum energy level of -2 such that
+        a binary quadratic model such that
         each constraint violation by a solution adds the default minimum energy gap.
 
-        >>> import dwavebinarycsp
         >>> import operator
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(operator.eq, ['a', 'b'])  # a == b
         >>> csp.add_constraint(operator.ne, ['b', 'c'])  # b != c
         >>> bqm = dwavebinarycsp.stitch(csp)
-        >>> bqm.energy({'a': 0, 'b': 0, 'c': 1})  # satisfies csp
+
+        Variable assignments that satisfy the CSP above, violate one, then two constraints,
+        produce energy increases of the default minimum classical gap:
+
+        >>> bqm.energy({'a': 0, 'b': 0, 'c': 1})  # doctest: +SKIP
         -2.0
-        >>> bqm.energy({'a': 0, 'b': 0, 'c': 0})  # violates one constraint
+        >>> bqm.energy({'a': 0, 'b': 0, 'c': 0})  # doctest: +SKIP
         0.0
-        >>> bqm.energy({'a': 1, 'b': 0, 'c': 0}) # violates two constraints
+        >>> bqm.energy({'a': 1, 'b': 0, 'c': 0}) #  doctest: +SKIP
         2.0
 
         This example creates a binary-valued constraint satisfaction problem
@@ -83,23 +86,26 @@ def stitch(csp, min_classical_gap=2.0, max_graph_size=8):
         Note that in this case the conversion to binary quadratic model adds two
         ancillary variables that must be minimized over when solving.
 
-        >>> import dwavebinarycsp
         >>> import operator
         >>> import itertools
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(operator.eq, ['a', 'b'])  # a == b
         >>> csp.add_constraint(operator.ne, ['b', 'c'])  # b != c
         >>> bqm = dwavebinarycsp.stitch(csp, min_classical_gap=4.0)
-        >>> list(bqm)   # # doctest: +SKIP
+        >>> list(bqm)   # doctest: +SKIP
         ['a', 'aux1', 'aux0', 'b', 'c']
+
+        Variable assignments that satisfy the CSP above, violate one, then two constraints,
+        produce energy increases of the specified minimum classical gap:
+
         >>> min([bqm.energy({'a': 0, 'b': 0, 'c': 1, 'aux0': aux0, 'aux1': aux1}) for
-        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # satisfies csp
+        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # doctest: +SKIP
         -6.0
         >>> min([bqm.energy({'a': 0, 'b': 0, 'c': 0, 'aux0': aux0, 'aux1': aux1}) for
-        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # violates one constraint
+        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # doctest: +SKIP
         -2.0
         >>> min([bqm.energy({'a': 1, 'b': 0, 'c': 0, 'aux0': aux0, 'aux1': aux1}) for
-        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # violates two constraints
+        ... aux0, aux1 in list(itertools.product([0, 1], repeat=2))])  # doctest: +SKIP
         2.0
 
         This example finds for the previous example the minimum graph size.

--- a/dwavebinarycsp/core/constraint.py
+++ b/dwavebinarycsp/core/constraint.py
@@ -61,7 +61,6 @@ class Constraint(Sized):
         is True for :math:`(y1,y0) = (x1,x0)+1` on binary variables, and demonstrates
         some of the constraint's functionality.
 
-        >>> import dwavebinarycsp
         >>> def plus_one(y1, y0, x1, x0):  # y=x++ for two bit binary numbers
         ...     return (y1, y0, x1, x0) in [(0, 1, 0, 0), (1, 0, 0, 1), (1, 1, 1, 0)]
         ...
@@ -82,7 +81,6 @@ class Constraint(Sized):
         that represents an AND gate for spin variables, and demonstrates some of
         the constraint's functionality.
 
-        >>> import dwavebinarycsp
         >>> const = dwavebinarycsp.Constraint.from_configurations(
         ...           [(-1, -1, -1), (-1, -1, 1), (-1, 1, -1), (1, 1, 1)],
         ...           ['y', 'x1', 'x2'],
@@ -153,7 +151,6 @@ class Constraint(Sized):
             This example creates a constraint that binary variables `a` and `b`
             are not equal.
 
-            >>> import dwavebinarycsp
             >>> import operator
             >>> const = dwavebinarycsp.Constraint.from_func(operator.ne, ['a', 'b'], 'BINARY')
             >>> print(const.name)
@@ -164,7 +161,6 @@ class Constraint(Sized):
             This example creates a constraint that :math:`out = NOT(x)`
             for spin variables.
 
-            >>> import dwavebinarycsp
             >>> def not_(y, x):  # y=NOT(x) for spin variables
             ...     return (y == -x)
             ...
@@ -212,7 +208,6 @@ class Constraint(Sized):
 
             This example creates a constraint that variables `a` and `b` are not equal.
 
-            >>> import dwavebinarycsp
             >>> const = dwavebinarycsp.Constraint.from_configurations([(0, 1), (1, 0)],
             ...                   ['a', 'b'], dwavebinarycsp.BINARY)
             >>> print(const.name)
@@ -223,7 +218,6 @@ class Constraint(Sized):
             This example creates a constraint based on specified valid configurations
             that represents an OR gate for spin variables.
 
-            >>> import dwavebinarycsp
             >>> const = dwavebinarycsp.Constraint.from_configurations(
             ...           [(-1, -1, -1), (1, -1, 1), (1, 1, -1), (1, 1, 1)],
             ...           ['y', 'x1', 'x2'],
@@ -342,7 +336,6 @@ class Constraint(Sized):
             and tests it for two candidate solutions, with additional unconstrained
             variable c.
 
-            >>> import dwavebinarycsp
             >>> const = dwavebinarycsp.Constraint.from_configurations([(0, 1), (1, 0)],
             ...             ['a', 'b'], dwavebinarycsp.BINARY)
             >>> solution = {'a': 1, 'b': 1, 'c': 0}
@@ -374,7 +367,6 @@ class Constraint(Sized):
             This example creates a constraint that :math:`a \\ne b` on binary variables,
             fixes variable a to 0, and tests two candidate solutions.
 
-            >>> import dwavebinarycsp
             >>> const = dwavebinarycsp.Constraint.from_func(operator.ne,
             ...             ['a', 'b'], dwavebinarycsp.BINARY)
             >>> const.fix_variable('a', 0)
@@ -422,7 +414,6 @@ class Constraint(Sized):
             This example creates a constraint that :math:`a = b` on binary variables
             and flips variable a.
 
-            >>> import dwavebinarycsp
             >>> const = dwavebinarycsp.Constraint.from_func(operator.eq,
             ...             ['a', 'b'], dwavebinarycsp.BINARY)
             >>> const.check({'a': 0, 'b': 0})
@@ -480,7 +471,6 @@ class Constraint(Sized):
             This example copies constraint :math:`a \\ne b` and tests a solution
             on the copied constraint.
 
-            >>> import dwavebinarycsp
             >>> import operator
             >>> const = dwavebinarycsp.Constraint.from_func(operator.ne,
             ...             ['a', 'b'], 'BINARY')

--- a/dwavebinarycsp/core/constraint.py
+++ b/dwavebinarycsp/core/constraint.py
@@ -506,16 +506,14 @@ class Constraint(Sized):
 
         Examples:
 
-            >>> import dwavebinarycsp
-            ...
             >>> const = dwavebinarycsp.Constraint.from_configurations([(0, 0), (0, 1)],
             ...                                                       ['a', 'b'],
             ...                                                       dwavebinarycsp.BINARY)
             >>> proj = const.projection(['a'])
             >>> proj.variables
-            ['a']
+            ('a',)
             >>> proj.configurations
-            {(0,)}
+            frozenset({(0,)})
 
         """
         # resolve iterables or mutability problems by casting the variables to a set

--- a/dwavebinarycsp/core/csp.py
+++ b/dwavebinarycsp/core/csp.py
@@ -55,7 +55,6 @@ class ConstraintSatisfactionProblem(object):
         This example creates a binary-valued constraint satisfaction problem, adds two constraints,
         :math:`a = b` and :math:`b \\ne c`, and tests :math:`a,b,c = 1,1,0`.
 
-        >>> import dwavebinarycsp
         >>> import operator
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem('BINARY')
         >>> csp.add_constraint(operator.eq, ['a', 'b'])
@@ -94,7 +93,6 @@ class ConstraintSatisfactionProblem(object):
             This example defines a function that evaluates True when the constraint is satisfied.
             The function's input arguments match the order and type of the `variables` argument.
 
-            >>> import dwavebinarycsp
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
             >>> def all_equal(a, b, c):  # works for both dwavebinarycsp.BINARY and dwavebinarycsp.SPIN
             ...     return (a == b) and (b == c)
@@ -106,7 +104,6 @@ class ConstraintSatisfactionProblem(object):
 
             This example explicitly lists allowed configurations.
 
-            >>> import dwavebinarycsp
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.SPIN)
             >>> eq_configurations = {(-1, -1), (1, 1)}
             >>> csp.add_constraint(eq_configurations, ['v0', 'v1'])
@@ -117,7 +114,6 @@ class ConstraintSatisfactionProblem(object):
 
             This example uses a :obj:`.Constraint` object built by :mod:`dwavebinarycsp.factories`.
 
-            >>> import dwavebinarycsp
             >>> import dwavebinarycsp.factories.constraint.gates as gates
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
             >>> csp.add_constraint(gates.and_gate(['a', 'b', 'c']))  # add an AND gate
@@ -152,7 +148,6 @@ class ConstraintSatisfactionProblem(object):
             This example adds two variables, one of which is already used in a constraint
             of the constraint satisfaction problem.
 
-            >>> import dwavebinarycsp
             >>> import operator
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.SPIN)
             >>> csp.add_constraint(operator.eq, ['a', 'b'])
@@ -182,7 +177,6 @@ class ConstraintSatisfactionProblem(object):
             and :math:`d = a \oplus c`, and verifies that the combined problem is satisfied
             for a given assignment.
 
-            >>> import dwavebinarycsp
             >>> import dwavebinarycsp.factories.constraint.gates as gates
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
             >>> csp.add_constraint(gates.and_gate(['a', 'b', 'c']))  # add an AND gate
@@ -209,7 +203,6 @@ class ConstraintSatisfactionProblem(object):
             This example creates a spin-valued constraint satisfaction problem, adds two constraints,
             :math:`a = b` and :math:`b \\ne c`, and fixes variable b to +1.
 
-            >>> import dwavebinarycsp
             >>> import operator
             >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.SPIN)
             >>> csp.add_constraint(operator.eq, ['a', 'b'])

--- a/dwavebinarycsp/factories/constraint/gates.py
+++ b/dwavebinarycsp/factories/constraint/gates.py
@@ -44,7 +44,6 @@ def and_gate(variables, vartype=dimod.BINARY, name='AND'):
         assigned values that match the valid states of an AND gate.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.gates as gates
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(gates.and_gate(['a', 'b', 'c'], name='AND1'))
@@ -93,7 +92,6 @@ def or_gate(variables, vartype=dimod.BINARY, name='OR'):
         assigned values that match the valid states of an OR gate.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.gates as gates
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.SPIN)
         >>> csp.add_constraint(gates.or_gate(['x', 'y', 'z'], {-1,1}, name='OR1'))
@@ -142,7 +140,6 @@ def xor_gate(variables, vartype=dimod.BINARY, name='XOR'):
         assigned values that match the valid states of an XOR gate.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.gates as gates
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(gates.xor_gate(['x', 'y', 'z'], name='XOR1'))
@@ -191,7 +188,6 @@ def halfadder_gate(variables, vartype=dimod.BINARY, name='HALF_ADDER'):
         assigned values that match the valid states of a Boolean half adder.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.gates as gates
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(gates.halfadder_gate(['a', 'b', 'total', 'carry'], name='HA1'))
@@ -249,7 +245,6 @@ def fulladder_gate(variables, vartype=dimod.BINARY, name='FULL_ADDER'):
         assigned values that match the valid states of a Boolean full adder.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.gates as gates
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(gates.fulladder_gate(['a', 'b', 'c_in', 'total', 'c_out'], name='FA1'))

--- a/dwavebinarycsp/factories/constraint/sat.py
+++ b/dwavebinarycsp/factories/constraint/sat.py
@@ -46,7 +46,6 @@ def sat2in4(pos, neg=tuple(), vartype=dimod.BINARY, name='2-in-4'):
         assigned values that satisfy a two-in-four satisfiability problem.
 
     Examples:
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories.constraint.sat as sat
         >>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
         >>> csp.add_constraint(sat.sat2in4(['w', 'x', 'y', 'z'], vartype='BINARY', name='sat1'))

--- a/dwavebinarycsp/factories/csp/circuits.py
+++ b/dwavebinarycsp/factories/csp/circuits.py
@@ -64,7 +64,6 @@ def multiplication_circuit(nbit, vartype=dimod.BINARY):
         as :math:`a=5, b=3` (:math:`101` and :math:`011`) and uses a simulated annealing sampler
         to find the product, :math:`p=15` (:math:`001111`).
 
-        >>> import dwavebinarycsp
         >>> from dwavebinarycsp.factories.csp.circuits import multiplication_circuit
         >>> import neal
         >>> csp = multiplication_circuit(3)

--- a/dwavebinarycsp/factories/csp/sat.py
+++ b/dwavebinarycsp/factories/csp/sat.py
@@ -53,7 +53,6 @@ def random_2in4sat(num_variables, num_clauses, vartype=dimod.BINARY, satisfiable
         This example creates a CSP with 6 variables and two random constraints and checks
         whether a particular assignment of variables satisifies it.
 
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories as sat
         >>> csp = sat.random_2in4sat(6, 2)
         >>> csp.constraints    # doctest: +SKIP
@@ -150,7 +149,6 @@ def random_xorsat(num_variables, num_clauses, vartype=dimod.BINARY, satisfiable=
         This example creates a CSP with 5 variables and two random constraints and checks
         whether a particular assignment of variables satisifies it.
 
-        >>> import dwavebinarycsp
         >>> import dwavebinarycsp.factories as sat
         >>> csp = sat.random_xorsat(5, 2)
         >>> csp.constraints    # doctest: +SKIP

--- a/dwavebinarycsp/reduction.py
+++ b/dwavebinarycsp/reduction.py
@@ -46,7 +46,6 @@ def irreducible_components(constraint):
         comparison, an attempt to reduce a constraint representing an AND gate fails to find a
         valid reduction.
 
-        >>> import dwavebinarycsp
         >>> const = dwavebinarycsp.Constraint.from_configurations([(0, 0, 1), (1, 1, 1)],
         ...                                                       ['a', 'b', 'c'], dwavebinarycsp.BINARY)
         >>> dwavebinarycsp.irreducible_components(const)


### PR DESCRIPTION
Currently there are 8 doctest fails. This PR fixes those and removes self-imports in docstring as we're now doing in other packages:
```
Doctest summary
===============
  176 tests
    0 failures in tests
    0 failures in setup code
    0 failures in cleanup code
build succeeded.
```