### PR TITLE
Fix warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 :warning: *dwavebinarycsp* is deprecated. For solving problems with constraints,
-    we recommend using the hybrid solvers in the Leap :tm: service. You can find
-    documentation for the hybrid solvers at https://docs.ocean.dwavesys.com.
+    we recommend using the hybrid solvers in the Leap\ :sup:`TM` service. You
+    can find documentation for the hybrid solvers at
+    https://docs.dwavequantum.com.
 
 .. image:: https://img.shields.io/pypi/v/dwavebinarycsp.svg
     :target: https://pypi.org/project/dwavebinarycsp

--- a/docs/reference/compilers.rst
+++ b/docs/reference/compilers.rst
@@ -7,7 +7,7 @@ Converting to a Binary Quadratic Model
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 

--- a/docs/reference/constraint.rst
+++ b/docs/reference/constraint.rst
@@ -7,7 +7,7 @@ Defining Constraints
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 

--- a/docs/reference/csp.rst
+++ b/docs/reference/csp.rst
@@ -7,7 +7,7 @@ Defining Constraint Satisfaction Problems
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 

--- a/docs/reference/factory_constraints.rst
+++ b/docs/reference/factory_constraints.rst
@@ -7,7 +7,7 @@ Factories
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 

--- a/docs/reference/loading.rst
+++ b/docs/reference/loading.rst
@@ -7,7 +7,7 @@ Other CSP Formats
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 

--- a/docs/reference/reduction.rst
+++ b/docs/reference/reduction.rst
@@ -7,7 +7,7 @@ Reducing Constraints
 .. deprecated:: 0.3.1
 
     ``dwavebinarycsp`` is deprecated and will be removed in Ocean 10.
-    For solving problems with constraints, we recommand using the hybrid
+    For solving problems with constraints, we recommend using the hybrid
     solvers in the Leap service.
     You can find documentation for the hybrid solvers at :ref:`opt_index_hybrid`.
 


### PR DESCRIPTION
Although GitHub renders :tm: in the SDK build there's a ``we recommend using the hybrid solvers in the Leap :tm: service`` message. 